### PR TITLE
Issue was with non - intersecting boxes

### DIFF
--- a/Autonomous driving application - Car detection - v1.ipynb
+++ b/Autonomous driving application - Car detection - v1.ipynb
@@ -400,7 +400,11 @@
     "    yi1 = np.max([box1[1], box2[1]])\n",
     "    xi2 = np.min([box1[2], box2[2]])\n",
     "    yi2 = np.min([box1[3], box2[3]])\n",
-    "    inter_area = (yi2 - yi1) * (xi2 - xi1)\n",
+    "    if (yi2 - yi1) and (xi2 - xi1) > 0:\n",
+    "        inter_area = (yi2 - yi1) * (xi2 - xi1)\n",
+    "    else:\n:,
+    "        inter_area = 0\n",
+    "    
     "    ### END CODE HERE ###    \n",
     "\n",
     "    # Calculate the Union area by using Formula: Union(A,B) = A + B - Inter(A,B)\n",


### PR DESCRIPTION
The earlier code didn't tackle the case of non intersecting boxes
Say box_1:(1 2 3 4) and box_2:(5 6 7 8)

Here, (yi2 - yi1) and (xi2 - xi1) are negative and on multiplication result in a positive inter_area where the actual case should be inter-area = 0 and they are dis-jointed

Please heed to this pull request